### PR TITLE
Fixing doublon

### DIFF
--- a/insee/documentation.md
+++ b/insee/documentation.md
@@ -39,6 +39,19 @@ In the `output.csv` the column names are like `NB_B314`  (which is the number of
 
 **Attention :** Un équipement  est défini comme un service rendu par un établissement. Ainsi, un établissement peut être compté plusieurs fois dans la base, s’il rend plusieurs services.
 
+## Précisions
+
+Certains indicateurs sont en doublons (ils apparaissent dans plusieurs fichiers) :
+- P11_PMEN
+- P11_POP0610
+- P11_POP1824
+- P11_POP1524
+- P11_POP2554
+- P11_POP80P
+- P11_POP5564
+
+Ils ont été dédoublonner dans le fichier final car ils ont strictement les même valeurs suivant leurs fichiers d'origines. Cependant ces doublons ont été garder dans cette documentation pour une meilleur compréhension.
+
 ##Nombre d'équipements et de services dans le domaine du commerce en 2013
 
  - NB_B101 : **Hypermarché**. Surface de vente déclarée supérieure à 2500 m²

--- a/insee/mk_data.py
+++ b/insee/mk_data.py
@@ -265,6 +265,7 @@ logement = logement[5:]
 
 # Adding CODGEO (iris ID) and other geo features witch are not in data
 features = [x for x in header if x not in ['IRIS', 'LIBIRIS']]
+features.remove('P11_PMEN') # P11_PMEN is already in Population file (https://github.com/anthill/open-moulinette/issues/18)
 [features.append(i) for i in ['CODGEO', 'LIBGEO']]
 
 key = ['CODGEO', 'LIBGEO', 'COM', 'LIBCOM', 'REG', 'DEP', 'UU2010']       
@@ -284,6 +285,8 @@ diplome = diplome[5:]
 
 # Adding CODGEO (iris ID) and other geo features witch are not in data
 features = [x for x in header if x not in ['IRIS', 'LIBIRIS']]
+features.remove('P11_POP0610') # P11_POP0610 is already in Population file (https://github.com/anthill/open-moulinette/issues/18)
+features.remove('P11_POP1824') # P11_POP1824 is already in Population file (https://github.com/anthill/open-moulinette/issues/18)
 [features.append(i) for i in ['CODGEO', 'LIBGEO']]
 
 key = ['CODGEO', 'LIBGEO', 'COM', 'LIBCOM', 'REG', 'DEP', 'UU2010',
@@ -304,6 +307,9 @@ famille = famille[5:]
 
 # Adding CODGEO (iris ID) and other geo features witch are not in data
 features = [x for x in header if x not in ['IRIS', 'LIBIRIS']]
+features.remove('P11_POP1524') # P11_POP1524 is already in Activité file (https://github.com/anthill/open-moulinette/issues/18)
+features.remove('P11_POP2554') # P11_POP2554 is already in Activité file (https://github.com/anthill/open-moulinette/issues/18)
+features.remove('P11_POP80P') # P11_POP80P is already in Population file (https://github.com/anthill/open-moulinette/issues/18)
 [features.append(i) for i in ['CODGEO', 'LIBGEO']]
 
 key = ['CODGEO', 'LIBGEO', 'COM', 'LIBCOM', 'REG', 'DEP', 'UU2010',
@@ -345,6 +351,7 @@ activite = activite[5:]
 
 # Adding CODGEO (iris ID) and other geo features witch are not in data
 features = [x for x in header if x not in ['IRIS', 'LIBIRIS']]
+features.remove('P11_POP5564') # P11_POP5564 is already in Population file (https://github.com/anthill/open-moulinette/issues/18)
 [features.append(i) for i in ['CODGEO', 'LIBGEO']]
 
 key = ['CODGEO', 'LIBGEO', 'COM', 'LIBCOM', 'REG', 'DEP', 'UU2010',


### PR DESCRIPTION
Fix #18 

Some features are present in different files : 
- 'P11_POP0610'
- 'P11_POP1824' 
- 'P11_POP80P' 
- 'P11_PMEN'
- 'P11_POP1524' 
- 'P11_POP2554'
- 'P11_POP5564'

Removing these features from one original file. Updating documentation.

```
[x for x in data.columns if x[-2:] == '_x'] # []
```
