### PR TITLE
Fix BasrevnuCom header change & update doc

### DIFF
--- a/caf/Makefile
+++ b/caf/Makefile
@@ -47,7 +47,8 @@ download_commune:
 	@wget -O source/TrancheAge2010.csv	http://data.caf.fr/dataset/d52a5176-195f-47c0-a851-b652e1d2875c/resource/8137ac83-32ca-48e4-a23e-d8f6263601fc/download/trancheage2010.csv
 	@wget -O source/TrancheAge2011.csv	http://data.caf.fr/dataset/d52a5176-195f-47c0-a851-b652e1d2875c/resource/02dc20f2-3a3d-4272-9893-07912fe563fd/download/trancheage2011.csv
 	@wget -O source/TrancheAge2012.csv	http://data.caf.fr/dataset/d52a5176-195f-47c0-a851-b652e1d2875c/resource/0f9dd215-eb6d-4479-90e0-0b0d951d5dec/download/trancheage2012.csv
-	@wget -O source/TrancheAge2013.csv	http://data.caf.fr/dataset/d52a5176-195f-47c0-a851-b652e1d2875c/resource/a6283267-9635-4452-b30e-35fe8a5cdbe2/download/trancheage2013.csv
+	#https://github.com/anthill/open-moulinette/issues/46
+	#@wget -O source/TrancheAge2013.csv	http://data.caf.fr/dataset/d52a5176-195f-47c0-a851-b652e1d2875c/resource/a6283267-9635-4452-b30e-35fe8a5cdbe2/download/trancheage2013.csv
 	@wget -O source/TrancheAge2014.csv	http://data.caf.fr/dataset/d52a5176-195f-47c0-a851-b652e1d2875c/resource/b46e67ea-66f9-4855-bc01-70690c1809dd/download/trancheage2014.csv
 
 	# LOGCom : http://data.caf.fr/dataset/population-des-foyers-allocataires-percevant-une-aide-personnelle-au-logement

--- a/caf/documentation.md
+++ b/caf/documentation.md
@@ -90,6 +90,8 @@ En 2009, 2010 et 2011, la première ligne (code 99999) recouvre, en plus des ré
 
  - **ALL_bas_revenu_yyyy** : nombre total de foyers allocataires bas revenus.
  - **Pers_bas_revenu_yyyy** : nombre total de personnes couvertes par les foyers bas revenus.
+ - **NB_allocataires_ress_yyyy** : nombre de foyers allocataires de référence pour le calcul des "bas revenus"
+ - **NB_pers_couv_ress_yyyy** : nombre de personnes couvertes de référence pour le calcul des "bas revenus"
 
 [source](http://data.caf.fr/dataset/beneficiaire-bas-revenus)
 

--- a/caf/scripts/BasrevnuCom.py
+++ b/caf/scripts/BasrevnuCom.py
@@ -11,8 +11,13 @@ import glob
 
 df = pd.read_csv('source/BasrevenuCom2009.csv', sep=";")
 
-df.columns = ['Communes', 'Codes_Insee', 'NB_Allocataires_2009', 
-              'ALL_bas_revenu_2009', 'Pers_bas_revenu_2009']
+
+# Old Columns parsing : https://github.com/anthill/open-moulinette/pull/40
+#df.columns = ['Communes', 'Codes_Insee', 'NB_Allocataires_2009', 
+#              'ALL_bas_revenu_2009', 'Pers_bas_revenu_2009']
+
+df.columns = ['Communes', 'Codes_Insee', 'ALL_bas_revenu_2009', 
+              'Pers_bas_revenu_2009', 'NB_pers_couv_ress_2009',  'NB_allocataires_2009']
 
 files = glob.glob('source/BasrevenuCom*')
 
@@ -24,7 +29,7 @@ for path_file in files:
         # Rename Col with year
         year_col = ['Communes', 'Codes_Insee']
         features_col = []
-        for col in df_temp.columns[-3:]:
+        for col in df_temp.columns[-4:]:
             year_col.append(col +"_"+ year)
             features_col.append(col +"_"+ year)
         
@@ -46,14 +51,16 @@ df.columns = list_col
 df.to_csv('data/full_BasrevenuCom.csv', encoding='utf-8', index=False)
 
 ## Features 
-#u'NB_Allocataires_2009_BC',
-#       u'ALL_bas_revenu_2009', u'Pers_bas_revenu_2009',
-#       u'NB_allocataires_2010_BC', u'ALL_bas_revenu_2010',
-#       u'Pers_bas_revenu_2010', u'NB_allocataires_2011_BC',
-#       u'ALL_bas_revenu_2011', u'Pers_bas_revenu_2011',
-#       u'NB_allocataires_2012_BC', u'ALL_bas_revenu_2012',
-#       u'Pers_bas_revenu_2012', u'NB_allocataires_2013_BC',
-#       u'ALL_bas_revenu_2013', u'Pers_bas_revenu_2013',
-#       u'NB_allocataires_2014_BC', u'ALL_bas_revenu_2014',
-#       u'Pers_bas_revenu_2014'
-
+#u'ALL_bas_revenu_2009',
+#       u'Pers_bas_revenu_2009', u'NB_pers_couv_ress_2009',
+#       u'NB_allocataires_2009_BC', u'ALL_bas_revenu_2010',
+#       u'Pers_bas_revenu_2010', u'NB_pers_couv_ress_2010',
+#       u'NB_allocataires_ress_2010_BC', u'ALL_bas_revenu_2011',
+#       u'Pers_bas_revenu_2011', u'NB_pers_couv_ress_2011',
+#       u'NB_allocataires_ress_2011_BC', u'ALL_bas_revenu_2012',
+#       u'Pers_bas_revenu_2012', u'NB_pers_couv_ress_2012',
+#       u'NB_allocataires_ress_2012_BC', u'ALL_bas_revenu_2013',
+#       u'Pers_bas_revenu_2013', u'NB_pers_couv_ress_2013',
+#       u'NB_allocataires_ress_2013_BC', u'ALL_bas_revenu_2014',
+#       u'Pers_bas_revenu_2014', u'NB_pers_couv_ress_2014',
+#       u'NB_allocataires_ress_2014_BC'


### PR DESCRIPTION
- fix #41 

Old header : 

```
['Communes', 'Codes_Insee', 'NB_Allocataires_2009', 
ALL_bas_revenu_2009', 'Pers_bas_revenu_2009']
```

New header
```
'Communes', 'Codes_Insee', 'ALL_bas_revenu_2009',
'Pers_bas_revenu_2009', 'NB_pers_couv_ress_2009',  'NB_allocataires_2009'
```

- Add description in documentation.